### PR TITLE
Feat: FE - Rank Reversal

### DIFF
--- a/frontend/components/commons/dataset-description/DatasetDescription.component.vue
+++ b/frontend/components/commons/dataset-description/DatasetDescription.component.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="description">
-    <h2 class="--heading5 --semibold description__title" >{{  title | capitalize }}</h2>
+    <h2 class="--heading5 --semibold description__title">
+      {{ title | capitalize }}
+    </h2>
     <RenderMarkdownBaseComponent
       class="--body1 description__text"
       :class="{ '--light': isColorLight }"
@@ -22,7 +24,7 @@ export default {
     },
   },
   created() {
-    this.title = this.$t("dataset.settings.annotationGuidelines")
+    this.title = this.$t("dataset.settings.annotationGuidelines");
   },
 };
 </script>

--- a/frontend/components/commons/forms/questions-form/fields/ranking/ranking-adapter.js
+++ b/frontend/components/commons/forms/questions-form/fields/ranking/ranking-adapter.js
@@ -1,7 +1,6 @@
 import { isNil } from "lodash";
 
 export const adaptQuestionsToSlots = ({ options }) => {
-
   // Adjustments: From 21/08/2023 the number of slots is fixed to 5 instead of following the number of options
   const slots = Array.from({ length: 5 }, (_, index) => {
     const id = index + 1;
@@ -11,7 +10,7 @@ export const adaptQuestionsToSlots = ({ options }) => {
       rank: id,
       items,
     };
-  })
+  });
 
   const questions = options.filter((o) => isNil(o.rank));
 

--- a/frontend/components/commons/forms/questions-form/fields/ranking/ranking-adapter.js
+++ b/frontend/components/commons/forms/questions-form/fields/ranking/ranking-adapter.js
@@ -1,7 +1,9 @@
 import { isNil } from "lodash";
 
 export const adaptQuestionsToSlots = ({ options }) => {
-  const slots = options.map((_, index) => {
+
+  // Adjustments: From 21/08/2023 the number of slots is fixed to 5 instead of following the number of options
+  const slots = Array.from({ length: 5 }, (_, index) => {
     const id = index + 1;
     const items = options.filter((option) => option.rank == id);
 
@@ -9,7 +11,7 @@ export const adaptQuestionsToSlots = ({ options }) => {
       rank: id,
       items,
     };
-  });
+  })
 
   const questions = options.filter((o) => isNil(o.rank));
 

--- a/frontend/components/commons/forms/questions-form/fields/ranking/ranking-adapter.test.js
+++ b/frontend/components/commons/forms/questions-form/fields/ranking/ranking-adapter.test.js
@@ -5,7 +5,7 @@ describe("Ranking adapter should", () => {
   it("get the same slots quantity that questions has", () => {
     const { slots, questions } = adaptQuestionsToSlots(settingsFake);
 
-    expect(slots.length).toBe(questions.length);
+    expect(slots.length).toBe(5);
   });
 
   it("has get adapted options as a question with name", () => {

--- a/frontend/components/commons/forms/questions-form/fields/ranking/ranking-adapter.test.js
+++ b/frontend/components/commons/forms/questions-form/fields/ranking/ranking-adapter.test.js
@@ -3,7 +3,7 @@ import { settingsFake } from "./ranking-fakes";
 
 describe("Ranking adapter should", () => {
   it("get the same slots quantity that questions has", () => {
-    const { slots, questions } = adaptQuestionsToSlots(settingsFake);
+    const { slots } = adaptQuestionsToSlots(settingsFake);
 
     expect(slots.length).toBe(5);
   });

--- a/frontend/components/commons/forms/questions-form/fields/shared-components/drag-and-drop-selection/DndSelection.component.vue
+++ b/frontend/components/commons/forms/questions-form/fields/shared-components/drag-and-drop-selection/DndSelection.component.vue
@@ -21,7 +21,7 @@
       <div
         class="draggable__slot"
         :class="{ '--active-slot': items.length }"
-        v-for="{ index, rank, items } in ranking.slots"
+        v-for="{ index, rank, items } in ranking.slots.reverse()"
         :key="index"
       >
         <span class="draggable__slot-box--ranking" v-text="rank" />

--- a/frontend/components/commons/forms/questions-form/fields/shared-components/drag-and-drop-selection/dndSelection.component.spec.js
+++ b/frontend/components/commons/forms/questions-form/fields/shared-components/drag-and-drop-selection/dndSelection.component.spec.js
@@ -4,7 +4,11 @@ import DndSelectionComponent from "./DndSelection.component";
 let wrapper = null;
 const options = {
   stubs: ["draggable"],
-  propsData: { ranking: {} },
+  propsData: { ranking: {
+      slots: {
+        reverse: jest.fn()
+      }
+  } },
 };
 
 beforeEach(() => {
@@ -12,7 +16,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  wrapper.destroy();
+  wrapper && wrapper.destroy();
 });
 
 describe("DndSelectionComponent", () => {

--- a/frontend/components/commons/forms/questions-form/fields/shared-components/drag-and-drop-selection/dndSelection.component.spec.js
+++ b/frontend/components/commons/forms/questions-form/fields/shared-components/drag-and-drop-selection/dndSelection.component.spec.js
@@ -4,11 +4,13 @@ import DndSelectionComponent from "./DndSelection.component";
 let wrapper = null;
 const options = {
   stubs: ["draggable"],
-  propsData: { ranking: {
+  propsData: {
+    ranking: {
       slots: {
-        reverse: jest.fn()
-      }
-  } },
+        reverse: jest.fn(),
+      },
+    },
+  },
 };
 
 beforeEach(() => {

--- a/frontend/components/page-contents/feedback-task-content/RecordFeedbackTaskAndQuestionnaire.content.vue
+++ b/frontend/components/page-contents/feedback-task-content/RecordFeedbackTaskAndQuestionnaire.content.vue
@@ -66,7 +66,9 @@ export default {
     },
     noMoreDataMessage() {
       return this.$t("datasets.youHaveReached", {
-        recordStatusToFilterWith: this.$t(`common.status.${this.recordStatusToFilterWith}`),
+        recordStatusToFilterWith: this.$t(
+          `common.status.${this.recordStatusToFilterWith}`
+        ),
       });
     },
     recordStatusFilterValueForGetRecords() {

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -28,8 +28,8 @@ config.mocks.localePath = (i) => i;
 config.mocks.$options = {
   filters: {
     capitalize: (i) => i,
-  }
-}
+  },
+};
 
 // these boolean switches turn off the build for all but the store
 const resetConfig = {


### PR DESCRIPTION
# Description

Set the number of drop areas (buckets) to be a fixed number (5) following the request made by the researcher team. 

**Type of change**

- [x] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

Jest 

![image](https://github.com/CLARIN-PL/argilla/assets/12537724/5f9512a1-3d46-41f3-ba8f-28e445cf5b96)


** Modified files**

- `frontend/components/commons/forms/questions-form/fields/ranking/ranking-adapter.js`: set the number of arrays to 5 
- `frontend/components/commons/forms/questions-form/fields/shared-components/drag-and-drop-selection/DndSelection.component.vue`: reverse the bucket order  
- `frontend/components/commons/forms/questions-form/fields/ranking/ranking-adapter.test.js`: adjusted the test to match the new requirement
- `frontend/components/commons/forms/questions-form/fields/shared-components/drag-and-drop-selection/dndSelection.component.spec.js`: adjusted the test to match the new requirement

The rest of the changes were caused by the linter. 

** Screenshots **

![image](https://github.com/CLARIN-PL/argilla/assets/12537724/07515a9b-7d0d-4388-87ca-16a7b548806b)


