### PR TITLE
Feat: FE - Hide empty text, bold title

### DIFF
--- a/frontend/components/feedback-task/RecordFeedbackTask.component.vue
+++ b/frontend/components/feedback-task/RecordFeedbackTask.component.vue
@@ -6,7 +6,7 @@
       :key="id"
     >
       <TextFieldComponent
-        v-if="isTextType"
+        v-if="isTextType && !!content.trim()"
         :title="name"
         :fieldText="content"
         :useMarkdown="settings.use_markdown"

--- a/frontend/components/feedback-task/field/TextField.component.vue
+++ b/frontend/components/feedback-task/field/TextField.component.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="text_field_component">
     <div class="title-area --body2">
-      <span v-text="title" />
+      <span class="title" v-text="title" />
       <BaseActionTooltip :tooltip="$t('common.copied')" tooltip-position="left">
         <BaseButton
           :title="$t('common.copyToClipboard')"
@@ -55,6 +55,10 @@ export default {
     justify-content: space-between;
     gap: $base-space;
     color: $black-87;
+
+    .title {
+      font-weight: bold;
+    }
   }
   .content-area {
     white-space: pre-wrap;


### PR DESCRIPTION
# Description

Made the title bold and hide the content from display when it's empty. 

**Type of change**

- [x] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

![image](https://github.com/CLARIN-PL/argilla/assets/12537724/ba2308d1-c7ea-4448-a9d2-eab8baf0ab4f)

**Checklist**

- [ ] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)

**Modified files**

- `frontend/components/feedback-task/RecordFeedbackTask.component.vue` : hide the content when there is nothing 
- `frontend/components/feedback-task/field/TextField.component.vue`: made the title bold

**Screenshots**
![image](https://github.com/CLARIN-PL/argilla/assets/12537724/9346264b-ab7a-4fb2-9cd6-fc8a36ccfac5)

