### PR TITLE
Feat: FE - Forces user to work only on one task at one time 

### DIFF
--- a/demo_task_with_context.ipynb
+++ b/demo_task_with_context.ipynb
@@ -1,0 +1,269 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "8f3590cc-f0dd-4bd0-969a-e0d62d11a233",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/artikandri/Work/clarin-pl/argilla/src/argilla/client/client.py:135: UserWarning: No workspace configuration was detected. To work with Argilla datasets, specify a valid workspace name on `rg.init` or set it up through the `rg.set_workspace` function.\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
+   "source": [
+    "import argilla as rg\n",
+    "import json\n",
+    "import pandas as pd\n",
+    "\n",
+    "rg.init(api_url=\"http://localhost:6900/\", api_key=\"admin.apikey\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "6348d808-8a32-4f78-9bd6-6cb95b9dbc25",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file = open('chats-dump-2023-07-13.jsonl', 'r')\n",
+    "chat_list = []\n",
+    "for line in file:\n",
+    "    # Parse each line as a JSON object\n",
+    "    json_obj = json.loads(line.strip())\n",
+    "    chat_list.append(json_obj)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "548fd80c-65a1-4ca3-92c2-1150e96c89c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prompts = []\n",
+    "answers = []\n",
+    "oids = []\n",
+    "timestamps = []\n",
+    "\n",
+    "for chat in chat_list:\n",
+    "    message = chat['messages']\n",
+    "    for mess in message:\n",
+    "        prompt = mess['prompt']\n",
+    "        reply = mess['answer']\n",
+    "        prompts.append(prompt)\n",
+    "        answers.append(reply)\n",
+    "        oids.append(chat['_id']['$oid'])\n",
+    "        timestamps.append(mess['timestamp']['$date'])\n",
+    "\n",
+    "df = pd.DataFrame({'prompt': prompts, 'reply': answers, '_id': oids, 'timestamp': timestamps})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "33aa1907-98f5-4e4b-bc93-691c742f6c82",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prev_context_dict = {}\n",
+    "\n",
+    "# Iterate through rows\n",
+    "prev_contexts = []\n",
+    "for _, row in df.iterrows():\n",
+    "    _id = row['_id']\n",
+    "    if _id not in prev_context_dict:\n",
+    "        prev_context_dict[_id] = []\n",
+    "\n",
+    "    prev_context = \"\\n\\n\".join(prev_context_dict[_id])\n",
+    "    prev_contexts.append(prev_context)\n",
+    "\n",
+    "    # prev_context_dict[_id].append(f\"**Prompt:** {row['prompt']} \\n <div style='text-align: right'> **Reply:** {row['reply']} </div>\")\n",
+    "    prev_context_dict[_id].append(f\"**Prompt:** {row['prompt']} \\n  **Reply:** {row['reply']}\")\n",
+    "\n",
+    "# Add 'prev_context' column to the DataFrame\n",
+    "df['prev_context'] = prev_contexts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "0c5ce80b-942f-40c2-bff8-d6bd1173568f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Pushing records to Argilla...: 100%|██████████| 4/4 [00:00<00:00,  5.78it/s]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<FeedbackDataset id=64f1699b-fdee-4da0-bd6b-99cee44ffa05 name=creating-answer-demo-no-prev-context-adjusted-demo workspace=Workspace(id=de99c898-074b-42f2-bb7c-15e25f8efd20, name=argilla, inserted_at=2023-08-18 14:11:56, updated_at=2023-08-18 14:11:56) url=http://localhost:6900/dataset/64f1699b-fdee-4da0-bd6b-99cee44ffa05/annotation-mode fields=[TextField(id=UUID('3ba4f652-2cdc-4a77-aefb-fd5d0be9c56f'), name='context', title='Previous context of current prompt', required=False, type='text', settings={'type': 'text', 'use_markdown': True}, use_markdown=True), TextField(id=UUID('95d1dfce-b975-42c9-b6f8-d945f1748e8e'), name='prompt', title='Current Prompt', required=True, type='text', settings={'type': 'text', 'use_markdown': True}, use_markdown=True)] questions=[TextQuestion(id=UUID('4387e305-ab1a-490c-9989-886da035b30a'), name='reply', title='Reply', description='Provide your reply based on the given prompt', required=True, type='text', settings={'type': 'text', 'use_markdown': False}, use_markdown=False)] guidelines=Given the following prompt, provide an appropriate reply>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dataset = rg.FeedbackDataset(\n",
+    "    guidelines=\"Given the following prompt, provide an appropriate reply\",\n",
+    "    fields=[\n",
+    "        rg.TextField(name=\"context\", title='Previous context of current prompt', required=False, use_markdown=True),\n",
+    "        rg.TextField(name=\"prompt\", title='Current Prompt', use_markdown=True),\n",
+    "    ],\n",
+    "    questions=[\n",
+    "        rg.TextQuestion(\n",
+    "            name=\"reply\",\n",
+    "            description=\"Provide your reply based on the given prompt\",\n",
+    "            required=True,\n",
+    "        ),\n",
+    "    ]\n",
+    ")\n",
+    "#E6E6E6\n",
+    "dataset.add_records(\n",
+    "    [\n",
+    "        rg.FeedbackRecord(\n",
+    "            fields={\n",
+    "                \"context\": data['prev_context'],\n",
+    "                \"prompt\": data['prompt'],\n",
+    "                # \"prompt\": f\"<span style='background:#B1B1B1'>{data['prompt']}</span>\",\n",
+    "            },\n",
+    "            metadata={\"chat_id\": data['_id']},\n",
+    "        ) for data in df.head(100).to_dict('records')\n",
+    "    ]\n",
+    ")\n",
+    "dataset.push_to_argilla(name=\"creating-answer-demo-no-prev-context-adjusted-demo\", workspace='argilla')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "066fe1f4-2eb4-430e-a9ed-7a36645cafcb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #800000; text-decoration-color: #800000\">╭─────────────────────────────── </span><span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">Traceback </span><span style=\"color: #bf7f7f; text-decoration-color: #bf7f7f; font-weight: bold\">(most recent call last)</span><span style=\"color: #800000; text-decoration-color: #800000\"> ────────────────────────────────╮</span>\n",
+       "<span style=\"color: #800000; text-decoration-color: #800000\">│</span> in <span style=\"color: #00ff00; text-decoration-color: #00ff00\">&lt;module&gt;</span>:<span style=\"color: #0000ff; text-decoration-color: #0000ff\">22</span>                                                                                   <span style=\"color: #800000; text-decoration-color: #800000\">│</span>\n",
+       "<span style=\"color: #800000; text-decoration-color: #800000\">│</span>                                                                                                  <span style=\"color: #800000; text-decoration-color: #800000\">│</span>\n",
+       "<span style=\"color: #800000; text-decoration-color: #800000\">│</span>   <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">19 </span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│   </span>fields=fields                                                                           <span style=\"color: #800000; text-decoration-color: #800000\">│</span>\n",
+       "<span style=\"color: #800000; text-decoration-color: #800000\">│</span>   <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">20 </span>)                                                                                           <span style=\"color: #800000; text-decoration-color: #800000\">│</span>\n",
+       "<span style=\"color: #800000; text-decoration-color: #800000\">│</span>   <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">21 </span>                                                                                            <span style=\"color: #800000; text-decoration-color: #800000\">│</span>\n",
+       "<span style=\"color: #800000; text-decoration-color: #800000\">│</span> <span style=\"color: #800000; text-decoration-color: #800000\">❱ </span>22 dataset.push_to_argilla(name=<span style=\"color: #808000; text-decoration-color: #808000\">\"ranking-task\"</span>, workspace=<span style=\"color: #808000; text-decoration-color: #808000\">'argilla'</span>)                           <span style=\"color: #800000; text-decoration-color: #800000\">│</span>\n",
+       "<span style=\"color: #800000; text-decoration-color: #800000\">│</span>   <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">23 </span>                                                                                            <span style=\"color: #800000; text-decoration-color: #800000\">│</span>\n",
+       "<span style=\"color: #800000; text-decoration-color: #800000\">│</span>                                                                                                  <span style=\"color: #800000; text-decoration-color: #800000\">│</span>\n",
+       "<span style=\"color: #800000; text-decoration-color: #800000\">│</span> <span style=\"color: #bfbf7f; text-decoration-color: #bfbf7f\">/home/artikandri/Work/clarin-pl/argilla/src/argilla/client/feedback/dataset/</span><span style=\"color: #808000; text-decoration-color: #808000; font-weight: bold\">mixins.py</span>:<span style=\"color: #0000ff; text-decoration-color: #0000ff\">171</span> in     <span style=\"color: #800000; text-decoration-color: #800000\">│</span>\n",
+       "<span style=\"color: #800000; text-decoration-color: #800000\">│</span> <span style=\"color: #00ff00; text-decoration-color: #00ff00\">push_to_argilla</span>                                                                                  <span style=\"color: #800000; text-decoration-color: #800000\">│</span>\n",
+       "<span style=\"color: #800000; text-decoration-color: #800000\">│</span>                                                                                                  <span style=\"color: #800000; text-decoration-color: #800000\">│</span>\n",
+       "<span style=\"color: #800000; text-decoration-color: #800000\">│</span>   <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">168 </span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│   │   </span>                                                                                   <span style=\"color: #800000; text-decoration-color: #800000\">│</span>\n",
+       "<span style=\"color: #800000; text-decoration-color: #800000\">│</span>   <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">169 </span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│   │   </span>dataset = feedback_dataset_in_argilla(name=name, workspace=workspace)              <span style=\"color: #800000; text-decoration-color: #800000\">│</span>\n",
+       "<span style=\"color: #800000; text-decoration-color: #800000\">│</span>   <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">170 </span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│   │   </span><span style=\"color: #0000ff; text-decoration-color: #0000ff\">if</span> dataset <span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">is</span> <span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">not</span> <span style=\"color: #0000ff; text-decoration-color: #0000ff\">None</span>:                                                            <span style=\"color: #800000; text-decoration-color: #800000\">│</span>\n",
+       "<span style=\"color: #800000; text-decoration-color: #800000\">│</span> <span style=\"color: #800000; text-decoration-color: #800000\">❱ </span>171 <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│   │   │   </span><span style=\"color: #0000ff; text-decoration-color: #0000ff\">raise</span> <span style=\"color: #00ffff; text-decoration-color: #00ffff\">RuntimeError</span>(                                                            <span style=\"color: #800000; text-decoration-color: #800000\">│</span>\n",
+       "<span style=\"color: #800000; text-decoration-color: #800000\">│</span>   <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">172 </span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">f\"Dataset with name=`{</span>name<span style=\"color: #808000; text-decoration-color: #808000\">}` and workspace=`{</span>workspace.name<span style=\"color: #808000; text-decoration-color: #808000\">}` already ex</span>   <span style=\"color: #800000; text-decoration-color: #800000\">│</span>\n",
+       "<span style=\"color: #800000; text-decoration-color: #800000\">│</span>   <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">173 </span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│   │   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">\" choose another name and/or workspace.\"</span>                                   <span style=\"color: #800000; text-decoration-color: #800000\">│</span>\n",
+       "<span style=\"color: #800000; text-decoration-color: #800000\">│</span>   <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">174 </span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">│   │   │   </span>)                                                                              <span style=\"color: #800000; text-decoration-color: #800000\">│</span>\n",
+       "<span style=\"color: #800000; text-decoration-color: #800000\">╰──────────────────────────────────────────────────────────────────────────────────────────────────╯</span>\n",
+       "<span style=\"color: #ff0000; text-decoration-color: #ff0000; font-weight: bold\">RuntimeError: </span>Dataset with <span style=\"color: #808000; text-decoration-color: #808000\">name</span>=`ranking-task` and <span style=\"color: #808000; text-decoration-color: #808000\">workspace</span>=`argilla` already exists in Argilla, please choose \n",
+       "another name and/or workspace.\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[31m╭─\u001b[0m\u001b[31m──────────────────────────────\u001b[0m\u001b[31m \u001b[0m\u001b[1;31mTraceback \u001b[0m\u001b[1;2;31m(most recent call last)\u001b[0m\u001b[31m \u001b[0m\u001b[31m───────────────────────────────\u001b[0m\u001b[31m─╮\u001b[0m\n",
+       "\u001b[31m│\u001b[0m in \u001b[92m<module>\u001b[0m:\u001b[94m22\u001b[0m                                                                                   \u001b[31m│\u001b[0m\n",
+       "\u001b[31m│\u001b[0m                                                                                                  \u001b[31m│\u001b[0m\n",
+       "\u001b[31m│\u001b[0m   \u001b[2m19 \u001b[0m\u001b[2m│   \u001b[0mfields=fields                                                                           \u001b[31m│\u001b[0m\n",
+       "\u001b[31m│\u001b[0m   \u001b[2m20 \u001b[0m)                                                                                           \u001b[31m│\u001b[0m\n",
+       "\u001b[31m│\u001b[0m   \u001b[2m21 \u001b[0m                                                                                            \u001b[31m│\u001b[0m\n",
+       "\u001b[31m│\u001b[0m \u001b[31m❱ \u001b[0m22 dataset.push_to_argilla(name=\u001b[33m\"\u001b[0m\u001b[33mranking-task\u001b[0m\u001b[33m\"\u001b[0m, workspace=\u001b[33m'\u001b[0m\u001b[33margilla\u001b[0m\u001b[33m'\u001b[0m)                           \u001b[31m│\u001b[0m\n",
+       "\u001b[31m│\u001b[0m   \u001b[2m23 \u001b[0m                                                                                            \u001b[31m│\u001b[0m\n",
+       "\u001b[31m│\u001b[0m                                                                                                  \u001b[31m│\u001b[0m\n",
+       "\u001b[31m│\u001b[0m \u001b[2;33m/home/artikandri/Work/clarin-pl/argilla/src/argilla/client/feedback/dataset/\u001b[0m\u001b[1;33mmixins.py\u001b[0m:\u001b[94m171\u001b[0m in     \u001b[31m│\u001b[0m\n",
+       "\u001b[31m│\u001b[0m \u001b[92mpush_to_argilla\u001b[0m                                                                                  \u001b[31m│\u001b[0m\n",
+       "\u001b[31m│\u001b[0m                                                                                                  \u001b[31m│\u001b[0m\n",
+       "\u001b[31m│\u001b[0m   \u001b[2m168 \u001b[0m\u001b[2m│   │   \u001b[0m                                                                                   \u001b[31m│\u001b[0m\n",
+       "\u001b[31m│\u001b[0m   \u001b[2m169 \u001b[0m\u001b[2m│   │   \u001b[0mdataset = feedback_dataset_in_argilla(name=name, workspace=workspace)              \u001b[31m│\u001b[0m\n",
+       "\u001b[31m│\u001b[0m   \u001b[2m170 \u001b[0m\u001b[2m│   │   \u001b[0m\u001b[94mif\u001b[0m dataset \u001b[95mis\u001b[0m \u001b[95mnot\u001b[0m \u001b[94mNone\u001b[0m:                                                            \u001b[31m│\u001b[0m\n",
+       "\u001b[31m│\u001b[0m \u001b[31m❱ \u001b[0m171 \u001b[2m│   │   │   \u001b[0m\u001b[94mraise\u001b[0m \u001b[96mRuntimeError\u001b[0m(                                                            \u001b[31m│\u001b[0m\n",
+       "\u001b[31m│\u001b[0m   \u001b[2m172 \u001b[0m\u001b[2m│   │   │   │   \u001b[0m\u001b[33mf\u001b[0m\u001b[33m\"\u001b[0m\u001b[33mDataset with name=`\u001b[0m\u001b[33m{\u001b[0mname\u001b[33m}\u001b[0m\u001b[33m` and workspace=`\u001b[0m\u001b[33m{\u001b[0mworkspace.name\u001b[33m}\u001b[0m\u001b[33m` already ex\u001b[0m   \u001b[31m│\u001b[0m\n",
+       "\u001b[31m│\u001b[0m   \u001b[2m173 \u001b[0m\u001b[2m│   │   │   │   \u001b[0m\u001b[33m\"\u001b[0m\u001b[33m choose another name and/or workspace.\u001b[0m\u001b[33m\"\u001b[0m                                   \u001b[31m│\u001b[0m\n",
+       "\u001b[31m│\u001b[0m   \u001b[2m174 \u001b[0m\u001b[2m│   │   │   \u001b[0m)                                                                              \u001b[31m│\u001b[0m\n",
+       "\u001b[31m╰──────────────────────────────────────────────────────────────────────────────────────────────────╯\u001b[0m\n",
+       "\u001b[1;91mRuntimeError: \u001b[0mDataset with \u001b[33mname\u001b[0m=`ranking-task` and \u001b[33mworkspace\u001b[0m=`argilla` already exists in Argilla, please choose \n",
+       "another name and/or workspace.\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "\n",
+    "questions = [\n",
+    "    rg.RankingQuestion(\n",
+    "        name=\"response_ranking\",\n",
+    "        title=\"Order the responses based on their accuracy and helpfulness:\",\n",
+    "        required=True,\n",
+    "        values={\"response-1\": \"Response 1\", \"response-2\": \"Response 2\"} # or [\"response-1\", \"response-2\"]\n",
+    "    ),\n",
+    "    rg.RankingQuestion(\n",
+    "        name=\"response_ranking\",\n",
+    "        title=\"Order the responses based on their accuracy and helpfulness:\",\n",
+    "        required=True,\n",
+    "        values={\"response-1\": \"Response 1\", \"response-2\": \"Response 2\"} # or [\"response-1\", \"response-2\"]\n",
+    "    ),\n",
+    "    rg.RankingQuestion(\n",
+    "        name=\"response_ranking\",\n",
+    "        title=\"Order the responses based on their accuracy and helpfulness:\",\n",
+    "        required=True,\n",
+    "        values={\"response-1\": \"Response 1\", \"response-2\": \"Response 2\"} # or [\"response-1\", \"response-2\"]\n",
+    "    )\n",
+    "]\n",
+    "\n",
+    "fields = [\n",
+    "    rg.TextField(name=\"prompt\", required=True),\n",
+    "    rg.TextField(name=\"response-1\", required=True),\n",
+    "    rg.TextField(name=\"response-2\", required=True)\n",
+    "]\n",
+    "\n",
+    "dataset = rg.FeedbackDataset(\n",
+    "\tguidelines=\"Please, read the prompt carefully and...\",\n",
+    "\tquestions=questions,\n",
+    "\tfields=fields\n",
+    ")\n",
+    "\n",
+    "dataset.push_to_argilla(name=\"ranking-task\", workspace='argilla')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
+++ b/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
@@ -95,7 +95,7 @@
           type="button"
           class="primary outline"
           @on-click="onDiscard"
-          :disabled="record.isDiscarded"
+          :disabled="record.isDiscarded || isDiscardButtonDisabled"
         >
           <span v-text="$t('common.discard')" />
         </BaseButton>
@@ -131,6 +131,8 @@ export default {
   data() {
     return {
       originalRecord: null,
+      isDiscardButtonDisabled: false,
+      isSubmitButtonDisabled: false,
     };
   },
   setup() {
@@ -186,22 +188,21 @@ export default {
       }
     },
     async onDiscard() {
+      this.isDiscardButtonDisabled = true;
       await this.discard(this.record);
-
       this.$emit("on-discard-responses");
-
       this.onReset();
+      this.isDiscardButtonDisabled = false;
     },
     async onSubmit() {
       if (!this.questionAreCompletedCorrectly) {
         return;
       }
-
+      this.isSubmitButtonDisabled = true;
       await this.submit(this.record);
-
       this.$emit("on-submit-responses");
-
       this.onReset();
+      this.isSubmitButtonDisabled = false;
     },
     async onClear() {
       await this.clear(this.record);

--- a/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
+++ b/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
@@ -102,7 +102,7 @@
         <BaseButton
           type="submit"
           class="primary"
-          :disabled="isSubmitButtonDisabled"
+          :disabled="isSubmitButtonDisabled || isSubmitButtonLoading"
         >
           <span v-text="$t('common.submit')" />
         </BaseButton>
@@ -132,7 +132,7 @@ export default {
     return {
       originalRecord: null,
       isDiscardButtonDisabled: false,
-      isSubmitButtonDisabled: false,
+      isSubmitButtonLoading: false,
     };
   },
   setup() {
@@ -198,11 +198,11 @@ export default {
       if (!this.questionAreCompletedCorrectly) {
         return;
       }
-      this.isSubmitButtonDisabled = true;
+      this.isSubmitButtonLoading = true;
       await this.submit(this.record);
       this.$emit("on-submit-responses");
       this.onReset();
-      this.isSubmitButtonDisabled = false;
+      this.isSubmitButtonLoading = false;
     },
     async onClear() {
       await this.clear(this.record);

--- a/frontend/components/commons/header/filters/SelectFilter.vue
+++ b/frontend/components/commons/header/filters/SelectFilter.vue
@@ -71,6 +71,7 @@
 </template>
 
 <script>
+import commonEn from "@/i18n/en/common/";
 export default {
   props: {
     filter: {
@@ -142,7 +143,9 @@ export default {
       return filtered;
     },
     optionName(option) {
-      return option[0];
+      return commonEn["status"][option[0].toLowerCase()]
+        ? this.$t(`common.status.${option[0].toLowerCase()}`)
+        : option[0];
     },
     optionCounter(option) {
       return option[1];

--- a/frontend/components/page-contents/feedback-task-content/RecordFeedbackTaskAndQuestionnaire.content.vue
+++ b/frontend/components/page-contents/feedback-task-content/RecordFeedbackTaskAndQuestionnaire.content.vue
@@ -67,8 +67,8 @@ export default {
     noMoreDataMessage() {
       return this.$t("datasets.youHaveReached", {
         recordStatusToFilterWith: this.$t(
-          `common.status.${this.recordStatusToFilterWith}`
-        ),
+          "common.status." + this.recordStatusToFilterWith
+        ).toLowerCase(),
       });
     },
     recordStatusFilterValueForGetRecords() {

--- a/frontend/database/index.js
+++ b/frontend/database/index.js
@@ -27,6 +27,7 @@ import { RecordField } from "@/models/feedback-task-model/record-field/RecordFie
 import { RecordResponse } from "@/models/feedback-task-model/record-response/RecordResponse.model";
 import { Pagination, DatasetViewSettings } from "@/models/DatasetViewSettings";
 import { Notification } from "@/models/Notifications";
+import { GeneralSettings } from "~/models/GeneralSettings";
 import { AnnotationProgress } from "@/models/AnnotationProgress";
 import { ObservationDataset } from "@/models/Dataset";
 import { Text2TextDataset } from "@/models/Text2Text";
@@ -42,6 +43,7 @@ import text_classification from "@/database/modules/text_classification";
 import token_classification from "@/database/modules/token_classification";
 
 import notifications from "@/database/modules/notifications";
+import general_settings from "@/database/modules/general_settings";
 
 const database = new Database();
 
@@ -57,6 +59,7 @@ database.register(DatasetViewSettings);
 database.register(Pagination);
 database.register(AnnotationProgress);
 database.register(Notification, notifications);
+database.register(GeneralSettings, general_settings);
 database.register(ObservationDataset, datasets);
 database.register(Text2TextDataset);
 database.register(TextClassificationDataset, text_classification);

--- a/frontend/database/modules/general_settings.ts
+++ b/frontend/database/modules/general_settings.ts
@@ -15,24 +15,11 @@
  * limitations under the License.
  */
 
-import { Context } from "@nuxt/types";
-import { GeneralSettings } from "~/models/GeneralSettings";
+const getters = {};
 
-export default ({ $auth, route, redirect }: Context) => {
-  GeneralSettings.insertOrUpdate({
-    data: {
-      id: $auth.user.id,
-      agent: $auth.user.username,
-    },
-  });
-  switch (route.name) {
-    case "login":
-      break;
-    default:
-      if (!$auth.loggedIn) {
-        const REDIRECT_URL =
-          "/login?redirect=" + encodeURIComponent(route.fullPath);
-        redirect(REDIRECT_URL);
-      }
-  }
+const actions = {};
+
+export default {
+  getters,
+  actions,
 };

--- a/frontend/i18n/en/common/index.js
+++ b/frontend/i18n/en/common/index.js
@@ -140,10 +140,13 @@ export default {
     yourChanges: "Your changes will be lost if you move to another page",
   },
   status: {
+    default: "Default",
     pending: "Pending",
     edited: "Edited",
     discarded: "Discarded",
     submitted: "Submitted",
     validated: "Validated",
+    negative: "Negative",
+    positive: "Positive",
   },
 };

--- a/frontend/i18n/pl/common/index.js
+++ b/frontend/i18n/pl/common/index.js
@@ -141,10 +141,13 @@ export default {
       "Twoje zmiany zostaną utracone, jeśli przejdziesz na inną stronę",
   },
   status: {
+    default: "Domyślny",
     pending: " Oczekujące",
     edited: "Edytowane",
     discarded: " Odrzucone",
     submitted: " Przesłane",
     validated: " Zatwierdzone",
+    negative: " Negatywne",
+    positive: " Pozytywne",
   },
 };

--- a/frontend/i18n/pl/datasets/index.js
+++ b/frontend/i18n/pl/datasets/index.js
@@ -94,5 +94,5 @@ export default {
   itsNotPossibleToDelete: "Usunięcie nie jest możliwe",
   ruleCantBeDeleted: "Nie można usunąć reguły '{query}'",
   ruleIsDeleted: "Reguła '{query}' została usunięta",
-  oneRecordCouldntBeSetAsNot: "1 rekord nie mógł zostać ustawiony jako nie",
+  oneRecordCouldntBeSetAsNot: "1 rekord nie mógł zostać ustawiony jako nie ",
 };

--- a/frontend/layouts/app.vue
+++ b/frontend/layouts/app.vue
@@ -31,6 +31,14 @@ export default {
       return this.$nuxt.isOffline;
     },
   },
+  created() {
+    // if(this.$auth.loggedIn) {
+    //   GeneralSettings.insertOrUpdate({data: {
+    //       id: this.$auth.user.id,
+    //       agent: this.$auth.user.username
+    //   }})
+    // }
+  },
   watch: {
     imOffline() {
       return Notification.dispatch("notify", {

--- a/frontend/layouts/app.vue
+++ b/frontend/layouts/app.vue
@@ -31,14 +31,6 @@ export default {
       return this.$nuxt.isOffline;
     },
   },
-  created() {
-    // if(this.$auth.loggedIn) {
-    //   GeneralSettings.insertOrUpdate({data: {
-    //       id: this.$auth.user.id,
-    //       agent: this.$auth.user.username
-    //   }})
-    // }
-  },
   watch: {
     imOffline() {
       return Notification.dispatch("notify", {

--- a/frontend/middleware/auth-guard.ts
+++ b/frontend/middleware/auth-guard.ts
@@ -19,12 +19,14 @@ import { Context } from "@nuxt/types";
 import { GeneralSettings } from "~/models/GeneralSettings";
 
 export default ({ $auth, route, redirect }: Context) => {
-  GeneralSettings.insertOrUpdate({
-    data: {
-      id: $auth.user.id,
-      agent: $auth.user.username,
-    },
-  });
+  if ($auth && $auth.user) {
+    GeneralSettings.insertOrUpdate({
+      data: {
+        id: $auth.user.id,
+        agent: $auth.user.username,
+      },
+    });
+  }
   switch (route.name) {
     case "login":
       break;

--- a/frontend/middleware/route-guard.ts
+++ b/frontend/middleware/route-guard.ts
@@ -21,8 +21,8 @@ import { GeneralSettings } from "~/models/GeneralSettings";
 import { GetDatasetsUseCase } from "@/v1/domain/usecases/get-datasets-use-case";
 
 export default async ({ $auth, route, redirect }: Context) => {
-  const getDatasetsUseCase = useResolve(GetDatasetsUseCase);
   if ($auth && $auth.user) {
+    const getDatasetsUseCase = useResolve(GetDatasetsUseCase);
     GeneralSettings.insertOrUpdate({
       data: {
         id: $auth.user.id,

--- a/frontend/middleware/route-guard.ts
+++ b/frontend/middleware/route-guard.ts
@@ -1,6 +1,6 @@
 /*
  * coding=utf-8
- * Copyright 2021-present, the Recognai S.L. team.
+ * Copyright 2023-present, CLARIN-PL team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/middleware/route-guard.ts
+++ b/frontend/middleware/route-guard.ts
@@ -31,7 +31,8 @@ export default async ({ $auth, route, redirect }: Context) => {
     });
     const userId: any = $auth.user.id || "";
     let settings: any = GeneralSettings.find(userId);
-    if ($auth.user.role !== "admin" && settings) {
+    const allowedRoles: any[] = ["admin", "owner"];
+    if (!allowedRoles.includes($auth.user.role) && settings) {
       if (!settings.current_dataset_name) {
         await getDatasetsUseCase.execute();
       }

--- a/frontend/middleware/route-guard.ts
+++ b/frontend/middleware/route-guard.ts
@@ -37,9 +37,14 @@ export default async ({ $auth, route, redirect }: Context) => {
       }
       settings = GeneralSettings.find(userId);
       const isNotOnCorrectDataset =
+        route.name.startsWith("datasets-") &&
         settings.current_dataset_name &&
         !route.fullPath.includes(settings.current_dataset_name);
-      if (route.name.startsWith("datasets-") && isNotOnCorrectDataset) {
+      const isNotOnCorrectDatasetFeedback =
+        route.name.startsWith("dataset-") &&
+        settings.current_dataset_id &&
+        !route.fullPath.includes(settings.current_dataset_id);
+      if (isNotOnCorrectDataset || isNotOnCorrectDatasetFeedback) {
         redirect("/datasets");
       }
     }

--- a/frontend/middleware/route-guard.ts
+++ b/frontend/middleware/route-guard.ts
@@ -22,10 +22,16 @@ import { GetDatasetsUseCase } from "@/v1/domain/usecases/get-datasets-use-case";
 
 export default async ({ $auth, route, redirect }: Context) => {
   const getDatasetsUseCase = useResolve(GetDatasetsUseCase);
-  if ($auth && $auth.user && $auth.user.role !== "admin") {
+  if ($auth && $auth.user) {
+    GeneralSettings.insertOrUpdate({
+      data: {
+        id: $auth.user.id,
+        agent: $auth.user.username,
+      },
+    });
     const userId: any = $auth.user.id || "";
     let settings: any = GeneralSettings.find(userId);
-    if (settings) {
+    if ($auth.user.role !== "admin" && settings) {
       if (!settings.current_dataset_name) {
         await getDatasetsUseCase.execute();
       }

--- a/frontend/middleware/route-guard.ts
+++ b/frontend/middleware/route-guard.ts
@@ -1,0 +1,41 @@
+/*
+ * coding=utf-8
+ * Copyright 2021-present, the Recognai S.L. team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Context } from "@nuxt/types";
+import { useResolve } from "ts-injecty";
+import { GeneralSettings } from "~/models/GeneralSettings";
+import { GetDatasetsUseCase } from "@/v1/domain/usecases/get-datasets-use-case";
+
+export default async ({ $auth, route, redirect }: Context) => {
+  const getDatasetsUseCase = useResolve(GetDatasetsUseCase);
+  if ($auth && $auth.user && $auth.user.role !== "admin") {
+    const userId: any = $auth.user.id || "";
+    let settings: any = GeneralSettings.find(userId);
+    if (settings) {
+      if (!settings.current_dataset_name) {
+        await getDatasetsUseCase.execute();
+      }
+      settings = GeneralSettings.find(userId);
+      const isNotOnCorrectDataset =
+        settings.current_dataset_name &&
+        !route.fullPath.includes(settings.current_dataset_name);
+      if (route.name.startsWith("datasets-") && isNotOnCorrectDataset) {
+        redirect("/datasets");
+      }
+    }
+  }
+};

--- a/frontend/models/GeneralSettings.js
+++ b/frontend/models/GeneralSettings.js
@@ -15,24 +15,20 @@
  * limitations under the License.
  */
 
-import { Context } from "@nuxt/types";
-import { GeneralSettings } from "~/models/GeneralSettings";
+import { Model } from "@vuex-orm/core";
 
-export default ({ $auth, route, redirect }: Context) => {
-  GeneralSettings.insertOrUpdate({
-    data: {
-      id: $auth.user.id,
-      agent: $auth.user.username,
-    },
-  });
-  switch (route.name) {
-    case "login":
-      break;
-    default:
-      if (!$auth.loggedIn) {
-        const REDIRECT_URL =
-          "/login?redirect=" + encodeURIComponent(route.fullPath);
-        redirect(REDIRECT_URL);
-      }
+class GeneralSettings extends Model {
+  static entity = "general_settings";
+
+  static fields() {
+    return {
+      id: this.attr(null),
+      agent: this.attr(null),
+      show_discard_button: this.boolean(false),
+      current_dataset_id: this.attr(null),
+      current_dataset_name: this.attr(null),
+    };
   }
-};
+}
+
+export { GeneralSettings };

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -186,7 +186,7 @@ const config: NuxtConfig = {
   i18n,
 
   router: {
-    middleware: ["auth-guard"],
+    middleware: ["auth-guard", "route-guard"],
     base: process.env.BASE_URL ?? "/",
   },
 

--- a/frontend/pages/dataset/_id/useDatasetViewModel.ts
+++ b/frontend/pages/dataset/_id/useDatasetViewModel.ts
@@ -72,5 +72,26 @@ export const useDatasetViewModel = () => {
     }
   };
 
-  return { dataset, datasetId, isLoadingDataset, loadDataset, breadcrumbs };
+  const loadDatasetWithMetrics = async () => {
+    try {
+      isLoadingDataset.value = true;
+
+      await getDatasetUseCase.execute(datasetId);
+    } catch (error) {
+      handleError(error.response);
+
+      router.push("/");
+    } finally {
+      isLoadingDataset.value = false;
+    }
+  };
+
+  return {
+    dataset,
+    datasetId,
+    isLoadingDataset,
+    loadDataset,
+    loadDatasetWithMetrics,
+    breadcrumbs,
+  };
 };

--- a/frontend/pages/dataset/_id/useDatasetViewModel.ts
+++ b/frontend/pages/dataset/_id/useDatasetViewModel.ts
@@ -72,26 +72,11 @@ export const useDatasetViewModel = () => {
     }
   };
 
-  const loadDatasetWithMetrics = async () => {
-    try {
-      isLoadingDataset.value = true;
-
-      await getDatasetUseCase.execute(datasetId);
-    } catch (error) {
-      handleError(error.response);
-
-      router.push("/");
-    } finally {
-      isLoadingDataset.value = false;
-    }
-  };
-
   return {
     dataset,
     datasetId,
     isLoadingDataset,
     loadDataset,
-    loadDatasetWithMetrics,
     breadcrumbs,
   };
 };

--- a/frontend/pages/datasets/_workspace/_dataset/index.vue
+++ b/frontend/pages/datasets/_workspace/_dataset/index.vue
@@ -75,6 +75,7 @@ import { getViewSettingsByDatasetName } from "@/models/viewSettings.queries";
 
 export default {
   layout: "app",
+  name: "WorkspaceDatasetIndex",
   async fetch() {
     // 1. Clean models before fetching data. Remaining model info could affect the generated query
     await this.cleanModels();

--- a/frontend/pages/datasets/_workspace/_dataset/index.vue
+++ b/frontend/pages/datasets/_workspace/_dataset/index.vue
@@ -76,6 +76,7 @@ import { getViewSettingsByDatasetName } from "@/models/viewSettings.queries";
 export default {
   layout: "app",
   name: "WorkspaceDatasetIndex",
+  middleware: ["route-guard"],
   async fetch() {
     // 1. Clean models before fetching data. Remaining model info could affect the generated query
     await this.cleanModels();

--- a/frontend/pages/datasets/index.vue
+++ b/frontend/pages/datasets/index.vue
@@ -56,6 +56,7 @@ import { useDatasetsViewModel } from "./useDatasetsViewModel";
 export default {
   layout: "app",
   name: "DatasetsIndex",
+  middleware: ["route-guard"],
   methods: {
     onBreadcrumbAction(e) {
       if (e === "clearFilters") {

--- a/frontend/pages/datasets/index.vue
+++ b/frontend/pages/datasets/index.vue
@@ -55,6 +55,7 @@ import { useDatasetsViewModel } from "./useDatasetsViewModel";
 
 export default {
   layout: "app",
+  name: "DatasetsIndex",
   methods: {
     onBreadcrumbAction(e) {
       if (e === "clearFilters") {

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -19,6 +19,7 @@
 </template>
 <script>
 export default {
+  name: "PageIndex",
   mounted() {
     this.$router.push("/datasets");
   },

--- a/frontend/pages/login.vue
+++ b/frontend/pages/login.vue
@@ -83,6 +83,7 @@
 </template>
 
 <script>
+import { GeneralSettings } from "~/models/GeneralSettings";
 export default {
   layout: "app",
   data() {
@@ -161,6 +162,12 @@ export default {
       await this.$store.dispatch("entities/deleteAll");
       await this.$auth.loginWith("authProvider", {
         data: this.encodedLoginData(authData),
+      });
+      GeneralSettings.insertOrUpdate({
+        data: {
+          id: this.$auth.user.id,
+          agent: this.$auth.user.username,
+        },
       });
 
       this.nextRedirect();

--- a/frontend/v1/domain/entities/Dataset.ts
+++ b/frontend/v1/domain/entities/Dataset.ts
@@ -9,7 +9,8 @@ export class Dataset {
     public readonly workspaceName: string,
     public readonly tags: unknown,
     public readonly createdAt: string,
-    public readonly updatedAt: string
+    public readonly updatedAt: string,
+    public readonly isCompleted: boolean
   ) {}
 
   public get workspace() {

--- a/frontend/v1/domain/usecases/get-datasets-use-case.ts
+++ b/frontend/v1/domain/usecases/get-datasets-use-case.ts
@@ -10,6 +10,7 @@ export class GetDatasetsUseCase {
   async execute() {
     const datasets = await this.datasetRepository.getAll();
 
+    this.datasetStorage.save([]);
     this.datasetStorage.save(datasets);
   }
 }

--- a/frontend/v1/infrastructure/repositories/DatasetRepository.ts
+++ b/frontend/v1/infrastructure/repositories/DatasetRepository.ts
@@ -78,15 +78,17 @@ export class DatasetRepository implements IDatasetRepository {
       datasets = datasets
         .filter((dataset) => dataset.status !== "completed")
         .splice(0, 1);
-    }
 
-    GeneralSettings.update({
-      where: this.store.$auth.$state.user.id,
-      data: {
-        current_dataset_id: datasets[0].id,
-        current_dataset_name: datasets[0].name,
-      },
-    });
+      if (datasets.length) {
+        GeneralSettings.update({
+          where: this.store.$auth.$state.user.id,
+          data: {
+            current_dataset_id: datasets[0].id,
+            current_dataset_name: datasets[0].name,
+          },
+        });
+      }
+    }
 
     return _.sortBy(datasets, (dataset) => dataset.name.toLowerCase());
   }

--- a/frontend/v1/infrastructure/repositories/DatasetRepository.ts
+++ b/frontend/v1/infrastructure/repositories/DatasetRepository.ts
@@ -73,10 +73,11 @@ export class DatasetRepository implements IDatasetRepository {
 
     // TODO: check dataset status and filter out datasets that are already completed (status: "completed")
     // and show only one dataset (the first one) that is in progress (status: "in_progress")
-    let datasets = [...otherDatasets, ...feedbackDatasets]
-    if(this.store.$auth.$state.user.role !== "admin") {
-      datasets = datasets.filter((dataset) => dataset.status !== "completed")
-      .splice(0, 1);
+    let datasets = [...otherDatasets, ...feedbackDatasets];
+    if (this.store.$auth.$state.user.role !== "admin") {
+      datasets = datasets
+        .filter((dataset) => dataset.status !== "completed")
+        .splice(0, 1);
     }
 
     GeneralSettings.update({

--- a/frontend/v1/infrastructure/repositories/DatasetRepository.ts
+++ b/frontend/v1/infrastructure/repositories/DatasetRepository.ts
@@ -76,7 +76,8 @@ export class DatasetRepository implements IDatasetRepository {
 
     const datasets = [...otherDatasets, ...feedbackDatasets];
     let filteredDatasets = datasets;
-    if (this.store.$auth.$state.user.role !== "admin") {
+    const allowedRoles: any[] = ["admin", "owner"];
+    if (!allowedRoles.includes(this.store.$auth.$state.user.role)) {
       const completedDatasets = datasets.filter(
         (dataset) => !dataset.isCompleted
       );

--- a/frontend/v1/infrastructure/repositories/DatasetRepository.ts
+++ b/frontend/v1/infrastructure/repositories/DatasetRepository.ts
@@ -73,9 +73,11 @@ export class DatasetRepository implements IDatasetRepository {
 
     // TODO: check dataset status and filter out datasets that are already completed (status: "completed")
     // and show only one dataset (the first one) that is in progress (status: "in_progress")
-    const datasets = [...otherDatasets, ...feedbackDatasets]
-      .filter((dataset) => dataset.status !== "completed")
+    let datasets = [...otherDatasets, ...feedbackDatasets]
+    if(this.store.$auth.$state.user.role !== "admin") {
+      datasets = datasets.filter((dataset) => dataset.status !== "completed")
       .splice(0, 1);
+    }
 
     GeneralSettings.update({
       where: this.store.$auth.$state.user.id,


### PR DESCRIPTION
# Description

This PR solves the request made by researchers to limit the number of tasks the user can work on at one time. It made use of the `.../metrics/` api and added `is_completed` property to the dataset based on the `metrics.aggregations` and `metrics.records`/`metrics.responses` counts. Additionally, the chosen dataset name (the first name) will be saved on the localStorage and it will be loaded if users tried to access other dataset by url, so user will be redirected to the `/datasets/` page. 

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

![image](https://github.com/CLARIN-PL/argilla/assets/12537724/17b224cb-d527-4fb1-896e-7be040e61a57)

**Checklist**

- [ ] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)

**New files**

- `frontend/middleware/route-guard.ts`: added a new routing guard to keep user from accessing other datasets by id 
- `frontend/models/GeneralSettings.js`: new VuexOrm model
- `frontend/database/modules/general_settings.ts`:  new VuexOrm model 

**Modified files**

- `frontend/components/commons/forms/questions-form/QuestionsForm.component.vue`: Added simple flags to disable the button on click 
- `frontend/components/commons/header/filters/SelectFilter.vue`: translated some texts
- `frontend/components/page-contents/feedback-task-content/RecordFeedbackTaskAndQuestionnaire.content.vue`: translated some texts 
- `frontend/database/index.js`: added the `GeneralSettings` model
-`frontend/database/modules/datasets.js`: translated the status, added `is_completed` flag to dataset with types other than `FeedbackTask`
- `frontend/i18n/*/common/index.js`: new translations
- `frontend/middleware/auth-guard.ts`: loaded GeneralSettings on first authorization
- `frontend/pages/datasets/_workspace/_dataset/index.vue` , `frontend/pages/datasets/index.vue`: added the guard on page template 
- `frontend/nuxt.config.ts`: added the guard on middleware 
- `frontend/pages/index.vue`: added the name
- `frontend/pages/login.vue`: initialize general settings after login
- `frontend/v1/domain/entities/Dataset.ts`: added isCompleted flag to the class model 
- `frontend/v1/infrastructure/repositories/DatasetRepository.ts`: added `is_completed` flag to the feedback datasets, filtered the dataset based on their completion status

Other changes were made by the linter. 

**Screenshots**
![image](https://github.com/CLARIN-PL/argilla/assets/12537724/44917ec9-5c49-4ae4-9d87-a6009e6166b6)

