### PR TITLE
Feat: FE - Added Pagination on Datasets page 

### DIFF
--- a/frontend/components/base/table/BaseTableInfo.vue
+++ b/frontend/components/base/table/BaseTableInfo.vue
@@ -203,6 +203,10 @@ export default {
       type: Array,
       default: () => [],
     },
+    originalData: {
+      type: Array,
+      default: () => [],
+    },
     actions: {
       type: Array,
       default: () => [],
@@ -306,7 +310,10 @@ export default {
         if (a[this.sortedBy] > b[this.sortedBy]) return 1 * modifier;
         return 0;
       };
-      const results = this.data.filter(matchSearch).filter(matchFilters);
+      let results = this.data.filter(matchSearch).filter(matchFilters);
+      if (!results.length) {
+        results = this.originalData.filter(matchSearch).filter(matchFilters);
+      }
       return results.sort(itemComparator);
     },
   },

--- a/frontend/components/features/datasets/DatasetsTable.vue
+++ b/frontend/components/features/datasets/DatasetsTable.vue
@@ -45,15 +45,6 @@ export default {
       required: true,
     },
   },
-  created() {
-    this.originalDatasets.forEach((dataset) => {
-      dataset.link = this.getDatasetLink(dataset);
-    });
-
-    this.datasets.forEach((dataset) => {
-      dataset.link = this.getDatasetLink(dataset);
-    });
-  },
   data() {
     return {
       querySearch: undefined,

--- a/frontend/components/features/datasets/DatasetsTable.vue
+++ b/frontend/components/features/datasets/DatasetsTable.vue
@@ -46,6 +46,10 @@ export default {
     },
   },
   created() {
+    this.originalDatasets.forEach((dataset) => {
+      dataset.link = this.getDatasetLink(dataset);
+    });
+
     this.datasets.forEach((dataset) => {
       dataset.link = this.getDatasetLink(dataset);
     });

--- a/frontend/components/features/datasets/DatasetsTable.vue
+++ b/frontend/components/features/datasets/DatasetsTable.vue
@@ -114,8 +114,8 @@ export default {
         title: this.$t("datasets.noDatasetsFound"),
       },
       externalLinks: [],
-      sortedOrder: "desc",
-      sortedByField: "updatedAt",
+      sortedOrder: "asc",
+      sortedByField: "createdAt",
     };
   },
   computed: {

--- a/frontend/components/features/datasets/DatasetsTable.vue
+++ b/frontend/components/features/datasets/DatasetsTable.vue
@@ -13,6 +13,7 @@
         search-on="name"
         :global-actions="false"
         :data="datasets"
+        :original-data="originalDatasets"
         :sorted-order="sortedOrder"
         :sorted-by-field="sortedByField"
         :actions="actions"
@@ -35,6 +36,10 @@ import { useRoutes } from "@/v1/infrastructure/services";
 
 export default {
   props: {
+    originalDatasets: {
+      type: Array,
+      default: () => [],
+    },
     datasets: {
       type: Array,
       required: true,
@@ -151,6 +156,7 @@ export default {
     },
     onSearch(event) {
       this.querySearch = event;
+      this.$emit("search", this.querySearch);
     },
     onSortColumns(by, order) {
       this.sortedByField = by;

--- a/frontend/layouts/app.vue
+++ b/frontend/layouts/app.vue
@@ -31,6 +31,14 @@ export default {
       return this.$nuxt.isOffline;
     },
   },
+  created() {
+    // if(this.$auth.loggedIn) {
+    //   GeneralSettings.insertOrUpdate({data: {
+    //       id: this.$auth.user.id,
+    //       agent: this.$auth.user.username
+    //   }})
+    // }
+  },
   watch: {
     imOffline() {
       return Notification.dispatch("notify", {

--- a/frontend/layouts/app.vue
+++ b/frontend/layouts/app.vue
@@ -31,14 +31,6 @@ export default {
       return this.$nuxt.isOffline;
     },
   },
-  created() {
-    // if(this.$auth.loggedIn) {
-    //   GeneralSettings.insertOrUpdate({data: {
-    //       id: this.$auth.user.id,
-    //       agent: this.$auth.user.username
-    //   }})
-    // }
-  },
   watch: {
     imOffline() {
       return Notification.dispatch("notify", {

--- a/frontend/pages/datasets/index.vue
+++ b/frontend/pages/datasets/index.vue
@@ -40,7 +40,7 @@
         />
         <base-pagination
           :one-page="onePage"
-          :total-items="datasetsCopy.length"
+          :total-items="datasetsOriginal.length"
           :pagination-settings="paginationSettings"
           :visible-page-range="5"
           @changePage="onClickChangePage"
@@ -79,9 +79,6 @@ export default {
     };
   },
   computed: {
-    datasetsCopy() {
-      return _.cloneDeep(this.datasetsAll);
-    },
     datasetsOriginal() {
       return this.datasets.datasets.map((dataset) => {
         dataset.link = this.getDatasetLink(dataset);
@@ -94,7 +91,7 @@ export default {
           ? 0
           : (this.currentPage - 1) * this.paginationSize;
       const nextIndex = currentIndex + this.paginationSize;
-      return this.datasetsCopy.slice(currentIndex, nextIndex);
+      return this.datasetsOriginal.slice(currentIndex, nextIndex);
     },
     paginationSettings() {
       return {

--- a/frontend/pages/datasets/index.vue
+++ b/frontend/pages/datasets/index.vue
@@ -31,7 +31,20 @@
           where="workspace datasets"
           :error="$fetchState.error"
         />
-        <datasets-table v-else ref="table" :datasets="datasets.datasets" />
+        <datasets-table
+          v-else
+          ref="table"
+          :original-datasets="datasets.datasets"
+          :datasets="datasetsByPage"
+          @search="onSearchDatasetsTable"
+        />
+        <base-pagination
+          :one-page="onePage"
+          :total-items="datasetsCopy.length"
+          :pagination-settings="paginationSettings"
+          :visible-page-range="5"
+          @changePage="onClickChangePage"
+        />
       </div>
       <sidebar-menu
         class="home__sidebar"
@@ -52,16 +65,55 @@
 
 <script>
 import { useDatasetsViewModel } from "./useDatasetsViewModel";
+import _ from "lodash";
 
 export default {
   layout: "app",
   name: "DatasetsIndex",
   middleware: ["route-guard"],
+  data() {
+    return {
+      currentPage: 1,
+      paginationSize: 5,
+      onePage: false,
+    };
+  },
+  computed: {
+    datasetsCopy() {
+      return _.cloneDeep(this.datasets.datasets);
+    },
+    datasetsByPage() {
+      const currentIndex =
+        this.currentPage === 1
+          ? 0
+          : (this.currentPage - 1) * this.paginationSize;
+      const nextIndex = currentIndex + this.paginationSize;
+      return this.datasetsCopy.slice(currentIndex, nextIndex);
+    },
+    paginationSettings() {
+      return {
+        page: this.currentPage,
+        size: this.paginationSize,
+        pageSizeOptions: [5, 10, 20, 50, 100],
+        maxRecordsLimit: 10000,
+        disabledShortCutPagination: false,
+      };
+    },
+  },
   methods: {
     onBreadcrumbAction(e) {
       if (e === "clearFilters") {
         this.$refs.table?.clearFilters();
       }
+    },
+    onSearchDatasetsTable(searchQuery) {
+      this.onePage = !!searchQuery;
+    },
+    onClickChangePage(currentPage, pageSize) {
+      this.currentPage = currentPage;
+      this.paginationSize = pageSize;
+
+      this.$forceUpdate();
     },
   },
   setup() {

--- a/frontend/pages/datasets/index.vue
+++ b/frontend/pages/datasets/index.vue
@@ -34,7 +34,7 @@
         <datasets-table
           v-else
           ref="table"
-          :original-datasets="datasets.datasets"
+          :original-datasets="datasetsOriginal"
           :datasets="datasetsByPage"
           @search="onSearchDatasetsTable"
         />
@@ -80,7 +80,13 @@ export default {
   },
   computed: {
     datasetsCopy() {
-      return _.cloneDeep(this.datasets.datasets);
+      return _.cloneDeep(this.datasetsAll);
+    },
+    datasetsOriginal() {
+      return this.datasets.datasets.map((dataset) => {
+        dataset.link = this.getDatasetLink(dataset);
+        return dataset;
+      });
     },
     datasetsByPage() {
       const currentIndex =
@@ -114,6 +120,18 @@ export default {
       this.paginationSize = pageSize;
 
       this.$forceUpdate();
+    },
+    isOldTask(task) {
+      return [
+        "TokenClassification",
+        "TextClassification",
+        "Text2Text",
+      ].includes(task);
+    },
+    getDatasetLink({ task, name, workspace, id }) {
+      return this.isOldTask(task)
+        ? `/datasets/${workspace}/${name}`
+        : `/dataset/${id}/annotation-mode`;
     },
   },
   setup() {

--- a/frontend/pages/datasets/index.vue
+++ b/frontend/pages/datasets/index.vue
@@ -82,6 +82,7 @@ export default {
     datasetsOriginal() {
       return this.datasets.datasets.map((dataset) => {
         dataset.link = this.getDatasetLink(dataset);
+        dataset.workspace = dataset.workspace || dataset.workspaceName;
         return dataset;
       });
     },
@@ -125,9 +126,10 @@ export default {
         "Text2Text",
       ].includes(task);
     },
-    getDatasetLink({ task, name, workspace, id }) {
+    getDatasetLink(dataset) {
+      const { task, workspace, id, name, workspaceName } = dataset
       return this.isOldTask(task)
-        ? `/datasets/${workspace}/${name}`
+        ? `/datasets/${workspace || workspaceName}/${name}`
         : `/dataset/${id}/annotation-mode`;
     },
   },

--- a/frontend/pages/datasets/index.vue
+++ b/frontend/pages/datasets/index.vue
@@ -65,7 +65,6 @@
 
 <script>
 import { useDatasetsViewModel } from "./useDatasetsViewModel";
-import _ from "lodash";
 
 export default {
   layout: "app",
@@ -127,7 +126,7 @@ export default {
       ].includes(task);
     },
     getDatasetLink(dataset) {
-      const { task, workspace, id, name, workspaceName } = dataset
+      const { task, workspace, id, name, workspaceName } = dataset;
       return this.isOldTask(task)
         ? `/datasets/${workspace || workspaceName}/${name}`
         : `/dataset/${id}/annotation-mode`;

--- a/frontend/v1/infrastructure/repositories/DatasetRepository.ts
+++ b/frontend/v1/infrastructure/repositories/DatasetRepository.ts
@@ -74,11 +74,19 @@ export class DatasetRepository implements IDatasetRepository {
       }
     );
 
-    const datasets = [...otherDatasets, ...feedbackDatasets].map((dataset) => {
-      return {
-        ...dataset,
-        createdAt: dataset.createdAt || dataset.insertedAt,
-      };
+    let datasets = [...otherDatasets, ...feedbackDatasets];
+    if (this.store.$auth.$state.user.role !== "admin") {
+      datasets = datasets
+        .filter((dataset) => dataset.status !== "completed")
+        .splice(0, 1);
+    }
+
+    GeneralSettings.update({
+      where: this.store.$auth.$state.user.id,
+      data: {
+        current_dataset_id: datasets[0].id,
+        current_dataset_name: datasets[0].name,
+      },
     });
     const orderedDatasets = sortBy(
       datasets,

--- a/frontend/v1/infrastructure/repositories/DatasetRepository.ts
+++ b/frontend/v1/infrastructure/repositories/DatasetRepository.ts
@@ -74,14 +74,11 @@ export class DatasetRepository implements IDatasetRepository {
       }
     );
 
-    let datasets = [...otherDatasets, ...feedbackDatasets];
-
-    GeneralSettings.update({
-      where: this.store.$auth.$state.user.id,
-      data: {
-        current_dataset_id: datasets[0].id,
-        current_dataset_name: datasets[0].name,
-      },
+    const datasets = [...otherDatasets, ...feedbackDatasets].map((dataset) => {
+      return {
+        ...dataset,
+        createdAt: dataset.createdAt || dataset.insertedAt,
+      };
     });
     const orderedDatasets = sortBy(
       datasets,

--- a/frontend/v1/infrastructure/repositories/DatasetRepository.ts
+++ b/frontend/v1/infrastructure/repositories/DatasetRepository.ts
@@ -75,11 +75,6 @@ export class DatasetRepository implements IDatasetRepository {
     );
 
     let datasets = [...otherDatasets, ...feedbackDatasets];
-    if (this.store.$auth.$state.user.role !== "admin") {
-      datasets = datasets
-        .filter((dataset) => dataset.status !== "completed")
-        .splice(0, 1);
-    }
 
     GeneralSettings.update({
       where: this.store.$auth.$state.user.id,

--- a/frontend/v1/infrastructure/repositories/DatasetRepository.ts
+++ b/frontend/v1/infrastructure/repositories/DatasetRepository.ts
@@ -83,7 +83,7 @@ export class DatasetRepository implements IDatasetRepository {
     const orderedDatasets = sortBy(
       datasets,
       [(dataset) => new Date(dataset.createdAt)],
-      ["asc"]
+      ["desc"]
     );
     let filteredDatasets = _.cloneDeep(orderedDatasets);
     const allowedRoles: any[] = ["admin", "owner"];

--- a/frontend/v1/infrastructure/repositories/DatasetRepository.ts
+++ b/frontend/v1/infrastructure/repositories/DatasetRepository.ts
@@ -1,6 +1,6 @@
 import { type NuxtAxiosInstance } from "@nuxtjs/axios";
 import { Store } from "vuex";
-import _, { sortBy } from "lodash";
+import _ from "lodash";
 import { Dataset } from "@/v1/domain/entities/Dataset";
 import { IDatasetRepository } from "@/v1/domain/services/IDatasetRepository";
 import { GeneralSettings } from "~/models/GeneralSettings";
@@ -80,12 +80,7 @@ export class DatasetRepository implements IDatasetRepository {
         createdAt: dataset.createdAt || dataset.insertedAt,
       };
     });
-    const orderedDatasets = sortBy(
-      datasets,
-      [(dataset) => new Date(dataset.createdAt)],
-      ["desc"]
-    );
-    let filteredDatasets = _.cloneDeep(orderedDatasets);
+    let filteredDatasets = _.cloneDeep(datasets);
     const allowedRoles: any[] = ["admin", "owner"];
     if (!allowedRoles.includes(this.store.$auth.$state.user.role)) {
       const completedDatasets = filteredDatasets.filter(

--- a/frontend/v1/infrastructure/services/useRoutes.ts
+++ b/frontend/v1/infrastructure/services/useRoutes.ts
@@ -13,9 +13,10 @@ export const useRoutes = () => {
     );
   };
 
-  const getDatasetLink = ({ task, name, workspace, id }: Dataset): string => {
+  const getDatasetLink = (dataset: Dataset): string => {
+    const { task, name, workspace, id, workspaceName } = dataset;
     return isOldTask(task)
-      ? `/datasets/${workspace}/${name}`
+      ? `/datasets/${workspace || workspaceName}/${name}`
       : `/dataset/${id}/annotation-mode`;
   };
 


### PR DESCRIPTION
# Description

Added pagination on datasets page. This pagination will work for admin and owner, and will just be there for annotators. 

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**
![image](https://github.com/CLARIN-PL/argilla/assets/12537724/594edc83-cfb9-4357-ba81-dd3be6e714e1)

**Checklist**

- [ ] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)

**Modified files**

- `frontend/components/base/table/BaseTableInfo.vue`: Added additional props (originalData)  to support the hack done to be able to reuse the pagination 
- `frontend/components/features/datasets/DatasetsTable.vue`: Added additional props (originalDatasets)  to support the hack done to be able to reuse the pagination 
- `frontend/pages/datasets/index.vue`: imported the pagination component, modified the flow a bit to support pagination 

**Screenshots**
user
![image](https://github.com/CLARIN-PL/argilla/assets/12537724/f069f690-33bd-4b72-b4ba-68e4d99468fc)
admin 
![image](https://github.com/CLARIN-PL/argilla/assets/12537724/b8208d37-2275-40d0-aed2-aa457584bc6c)
![image](https://github.com/CLARIN-PL/argilla/assets/12537724/6eb741f8-3f3c-4db6-8ee8-6719dc88f29b)
