### PR TITLE
Fix: FE - Insufficient resources

### DIFF
--- a/frontend/database/modules/datasets.js
+++ b/frontend/database/modules/datasets.js
@@ -838,7 +838,9 @@ const actions = {
      */
     const { data } = await this.$axios.get("/datasets/");
     const API_COUNT_LIMIT = 100;
-    if (data.length) {
+    const allowedRoles = ["admin", "owner"];
+    const isUser = !allowedRoles.includes(this.$auth.$state.user.role);
+    if (data.length && isUser) {
       let startIndex = 0;
       let endIndex = data.length;
       const numberOfRequests = Math.ceil(data.length / API_COUNT_LIMIT);
@@ -883,6 +885,7 @@ const actions = {
             return response.data;
           });
         await Promise.all(promises);
+
         startIndex = (i + 1) * API_COUNT_LIMIT;
         endIndex = endIndex + API_COUNT_LIMIT;
         if (endIndex > data.items.length) {

--- a/frontend/database/modules/datasets.js
+++ b/frontend/database/modules/datasets.js
@@ -837,38 +837,59 @@ const actions = {
      * Fetch all observation datasets from backend
      */
     const { data } = await this.$axios.get("/datasets/");
+    const API_COUNT_LIMIT = 100;
     if (data.length) {
-      const promises = data.map(async (dataset) => {
-        const { response } = await ObservationDataset.api().post(
-          `/datasets/${dataset.name}/${dataset.task}:search?limit=0&from=0&workspace=${dataset.workspace}`,
-          {
-            query: {},
-            sort: [],
-          },
-          {
-            save: false,
-          }
-        );
-        dataset.metrics = response.data;
-        if (dataset.metrics.aggregations) {
-          const { status, total } = dataset.metrics.aggregations;
-          const statusKeys = Object.keys(status);
-          dataset.is_completed = false;
-          if (statusKeys.length === 1 && statusKeys.includes("Default")) {
-            dataset.is_completed = false;
-          } else if (statusKeys.length > 1 && statusKeys.includes("Default")) {
-            let totalOther = 0;
-            statusKeys
-              .filter((key) => key !== "Default")
-              .forEach((key) => {
-                totalOther += status[key];
-              });
-            dataset.is_completed = totalOther === total;
-          }
+      let startIndex = 0;
+      let endIndex = data.length;
+      const numberOfRequests = Math.ceil(data.length / API_COUNT_LIMIT);
+
+      if (data.length > API_COUNT_LIMIT) {
+        endIndex = API_COUNT_LIMIT;
+      }
+      for (let i = 0; i < numberOfRequests; i++) {
+        const promises = data
+          .slice(startIndex, endIndex)
+          .map(async (dataset) => {
+            const { response } = await ObservationDataset.api().post(
+              `/datasets/${dataset.name}/${dataset.task}:search?limit=0&from=0&workspace=${dataset.workspace}`,
+              {
+                query: {},
+                sort: [],
+              },
+              {
+                save: false,
+              }
+            );
+            dataset.metrics = response.data;
+            if (dataset.metrics.aggregations) {
+              const { status, total } = dataset.metrics.aggregations;
+              const statusKeys = Object.keys(status);
+              dataset.is_completed = false;
+              if (statusKeys.length === 1 && statusKeys.includes("Default")) {
+                dataset.is_completed = false;
+              } else if (
+                statusKeys.length > 1 &&
+                statusKeys.includes("Default")
+              ) {
+                let totalOther = 0;
+                statusKeys
+                  .filter((key) => key !== "Default")
+                  .forEach((key) => {
+                    totalOther += status[key];
+                  });
+                dataset.is_completed = totalOther === total;
+              }
+            }
+            return response.data;
+          });
+        await Promise.all(promises);
+        startIndex = (i + 1) * API_COUNT_LIMIT;
+        endIndex = endIndex + API_COUNT_LIMIT;
+        if (endIndex > data.items.length) {
+          endIndex = data.items.length;
         }
-        return response.data;
-      });
-      await Promise.all(promises);
+        setTimeout(() => {}, 1000);
+      }
     }
 
     return data;

--- a/frontend/v1/infrastructure/repositories/DatasetRepository.ts
+++ b/frontend/v1/infrastructure/repositories/DatasetRepository.ts
@@ -134,7 +134,9 @@ export class DatasetRepository implements IDatasetRepository {
     try {
       const { data } = await axios.get("/v1/me/datasets");
       const API_COUNT_LIMIT = 100;
-      if (data.items && data.items.length) {
+      const allowedRoles: any[] = ["admin", "owner"];
+      const isUser = !allowedRoles.includes(this.store.$auth.$state.user.role);
+      if (data.items && data.items.length && isUser) {
         let startIndex = 0;
         let endIndex = data.items.length;
         const numberOfRequests = Math.ceil(data.items.length / API_COUNT_LIMIT);


### PR DESCRIPTION
# Description

This PR is made to handle a bug when the user have too much tasks assigned. As for now, the task completed status is loaded by using the combination of the `metrics/` api with `Promise.all`, which means that the browser will load the metrics for each dataset item at the same  time. However, this approach wont work when user have too much tasks assigned to them, because the browser will load more requests than it could handle, hence `insufficient resources` error. With this pr, only 100 requests are loaded at one time, then 1min of rest before loading the next 100+ and so on. 

Additionally, I removed the metrics loading for admin/owner, because after giving it some thought, I don't think they need to know their data completion status. 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**How Has This Been Tested**
![Screenshot from 2023-10-06 17-49-00](https://github.com/CLARIN-PL/argilla/assets/12537724/bd9538c6-8d2b-4ec3-8ac7-0592b6e687d7)

**Checklist**

- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/

**Modified files**
- `frontend/database/modules/datasets.js`: added the api limit 
- `frontend/v1/infrastructure/repositories/DatasetRepository.ts`: added the api limit 
