### PR TITLE
Fix: BE - Enlarging number of shards 

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -31,7 +31,7 @@ services:
     environment:
       - node.name=elasticsearch
       - cluster.name=es-argilla-local
-      - cluster.max_shards_per_node=10000
+      - cluster.max_shards_per_node=20000
       - discovery.type=single-node
       - "ES_JAVA_OPTS=-Xms2g -Xmx2g"
       - cluster.routing.allocation.disk.threshold_enabled=false


### PR DESCRIPTION
The number of shards in ES right now is not sufficient. It was already enlarged to 10k before, but the problem persists, so the shard number is now enlarged again to 20k.

**Checklist**

- [ ] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)

**Modified files**

- `docker/docker-compose.yaml`: Bigger shards 

**Error**

```
2023-10-10 15:39:00,192 - ERROR: Exception occurred: Failed while publishing the `FeedbackDataset` in Argilla with exception: Argilla server returned an error with http status: 500
Error details: [{'code': 'argilla.api.errors::GenericServerError', 'params': {'type': 'opensearchpy.exceptions.RequestError', 'message': 'RequestError(400, \'{"error":{"root_cause":[{"type":"validation_exception","reason":"Validation Failed: 1: this action would add [2] shards, but this cluster currently has [10000]/[10000] maximum normal shards open;"}],"type":"validation_exception","reason":"Validation Failed: 1: this action would add [2] shards, but this cluster currently has [10000]/[10000] maximum normal shards open;"},"status":400}\')'}}]
Traceback (most recent call last):
  File "/home/acandri/.local/lib/python3.8/site-packages/argilla/client/feedback/dataset/mixins.py", line 92, in __publish_dataset
    datasets_api_v1.publish_dataset(client=client, id=id)
  File "/home/acandri/.local/lib/python3.8/site-packages/argilla/client/sdk/v1/datasets/api.py", line 145, in publish_dataset
    return handle_response_error(response)
  File "/home/acandri/.local/lib/python3.8/site-packages/argilla/client/sdk/commons/errors_handler.py", line 64, in handle_response_error
    raise error_type(**error_args)
argilla.client.sdk.commons.errors.GenericApiError: Argilla server returned an error with http status: 500
Error details: [{'code': 'argilla.api.errors::GenericServerError', 'params': {'type': 'opensearchpy.exceptions.RequestError', 'message': 'RequestError(400, \'{"error":{"root_cause":[{"type":"validation_exception","reason":"Validation Failed: 1: this action would add [2] shards, but this cluster currently has [10000]/[10000] maximum normal shards open;"}],"type":"validation_exception","reason":"Validation Failed: 1: this action would add [2] shards, but this cluster currently has [10000]/[10000] maximum normal shards open;"},"status":400}\')'}}]

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "pl_pipeline_v2.py", line 168, in task_create_answer
    dataset.push_to_argilla(name=task_name, workspace=ws)
  File "/home/acandri/.local/lib/python3.8/site-packages/argilla/client/feedback/dataset/mixins.py", line 189, in push_to_argilla
    self.__publish_dataset(client=httpx_client, id=argilla_id)
  File "/home/acandri/.local/lib/python3.8/site-packages/argilla/client/feedback/dataset/mixins.py", line 95, in __publish_dataset
    raise Exception(f"Failed while publishing the `FeedbackDataset` in Argilla with exception: {e}") from e
Exception: Failed while publishing the `FeedbackDataset` in Argilla with exception: Argilla server returned an error with http status: 500
Error details: [{'code': 'argilla.api.errors::GenericServerError', 'params': {'type': 'opensearchpy.exceptions.RequestError', 'message': 'RequestError(400, \'{"error":{"root_cause":[{"type":"validation_exception","reason":"Validation Failed: 1: this action would add [2] shards, but this cluster currently has [10000]/[10000] maximum normal shards open;"}],"type":"validation_exception","reason":"Validation Failed: 1: this action would add [2] shards, but this cluster currently has [10000]/[10000] maximum normal shards open;"},"status":400}\')'}}]

```