### PR TITLE
Feat: FE - Added breaks on the list 

### DIFF
--- a/frontend/components/base/render-markdown/RenderMarkdown.base.component.vue
+++ b/frontend/components/base/render-markdown/RenderMarkdown.base.component.vue
@@ -26,7 +26,10 @@ export default {
   },
   methods: {
     cleanMarkdown(markdown) {
-      return markdown.replace(/[^\S\r\n]+$/gm, "");
+      const markdowns = markdown.replace(/[^\S\r\n]+$/gm, "").split(/[0-9][\/.]/g)
+      return markdowns.length < 2 ? 
+        markdowns.join("") : 
+        markdowns.map((x, i) => `${i+0}. ${x}`).slice(1, markdowns.length).join("\n\n")
     },
   },
   computed: {
@@ -48,6 +51,13 @@ export default {
   white-space: normal;
   word-break: break-word;
   :deep() {
+
+    p {
+      &:contains("0.") {
+        display: none;
+      }
+    }
+   
     hr {
       width: 100%;
     }
@@ -86,6 +96,7 @@ export default {
       margin-bottom: $base-space;
     }
   }
+
 }
 :deep() {
   .hljs {

--- a/frontend/components/base/render-markdown/RenderMarkdown.base.component.vue
+++ b/frontend/components/base/render-markdown/RenderMarkdown.base.component.vue
@@ -26,10 +26,15 @@ export default {
   },
   methods: {
     cleanMarkdown(markdown) {
-      const markdowns = markdown.replace(/[^\S\r\n]+$/gm, "").split(/[0-9][\/.]/g)
-      return markdowns.length < 2 ? 
-        markdowns.join("") : 
-        markdowns.map((x, i) => `${i+0}. ${x}`).slice(1, markdowns.length).join("\n\n")
+      const markdowns = markdown
+        .replace(/[^\S\r\n]+$/gm, "")
+        .split(/[0-9][/.]/g);
+      return markdowns.length < 2
+        ? markdowns.join("")
+        : markdowns
+            .map((x) => `- ${x}`)
+            .slice(1, markdowns.length)
+            .join("\n\n");
     },
   },
   computed: {
@@ -51,13 +56,12 @@ export default {
   white-space: normal;
   word-break: break-word;
   :deep() {
-
     p {
       &:contains("0.") {
         display: none;
       }
     }
-   
+
     hr {
       width: 100%;
     }
@@ -96,7 +100,6 @@ export default {
       margin-bottom: $base-space;
     }
   }
-
 }
 :deep() {
   .hljs {


### PR DESCRIPTION
This PR deals with list views. Currently, the list doesnt have a line break between the number. This is because the current data doesnt support new lines -  the markdown data is saved as json, however json only supports `\n` as line breaks and somehow when I tried to regex-replaced the data to add `\n`, the database got broken  :1st_place_medal:    Because of that, I added the regex on the frontend instead. 

This approach is `naive` since it only added new line break before a number  `n.`, meaning if a paragraph has `n. ` inside of it (ex: `This paragraph ended at line 2. Paragraph shouldn't have been processed as list.`), it will break the sentences as:

 ```
This paragraph ended at line
1. Paragraph shouldn't have been processed as list
```

However at the moment there is no other solution, so for the time being I will put this here. 

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [ ] Improvement (change adding some improvement to an existing functionality)
- [ ] Documentation update

**How Has This Been Tested**
![Screenshot from 2023-10-06 17-49-00](https://github.com/CLARIN-PL/argilla/assets/12537724/ad80d73e-a3d2-4ddf-a84d-87278bd542b8)

**Checklist**

- [x] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)

**Modified files**

- `frontend/components/base/render-markdown/RenderMarkdown.base.component.vue` : added the regex and joined it by adding the index as the numbering. 
