### PR TITLE
Fix: FE - Tooltip, Label Width

### DIFF
--- a/frontend/components/commons/forms/questions-form/fields/shared-components/label-selection/LabelSelection.component.vue
+++ b/frontend/components/commons/forms/questions-form/fields/shared-components/label-selection/LabelSelection.component.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="container">
-    <div class="component-header" v-if="showSearch || showCollapseButton">
+    <div
+      class="component-header"
+      v-if="showSearch || showCollapseButton"
+    >
       <div class="left-header">
         <SearchLabelComponent
           ref="searchComponentRef"
@@ -62,7 +65,10 @@
         />
       </div>
     </transition-group>
-    <i class="no-result" v-if="!filteredOptions.length" />
+    <i
+      class="no-result"
+      v-if="!filteredOptions.length"
+    />
   </div>
 </template>
 
@@ -236,7 +242,8 @@ export default {
   width: 100%;
   height: 32px;
   min-width: 50px;
-  max-width: 200px;
+  // max-width: 200px;
+  max-width: 250px;
   text-align: center;
   padding-inline: 12px;
   background: palette(purple, 800);

--- a/frontend/components/commons/forms/questions-form/fields/shared-components/label-selection/LabelSelection.component.vue
+++ b/frontend/components/commons/forms/questions-form/fields/shared-components/label-selection/LabelSelection.component.vue
@@ -1,9 +1,6 @@
 <template>
   <div class="container">
-    <div
-      class="component-header"
-      v-if="showSearch || showCollapseButton"
-    >
+    <div class="component-header" v-if="showSearch || showCollapseButton">
       <div class="left-header">
         <SearchLabelComponent
           ref="searchComponentRef"
@@ -65,10 +62,7 @@
         />
       </div>
     </transition-group>
-    <i
-      class="no-result"
-      v-if="!filteredOptions.length"
-    />
+    <i class="no-result" v-if="!filteredOptions.length" />
   </div>
 </template>
 
@@ -242,7 +236,6 @@ export default {
   width: 100%;
   height: 32px;
   min-width: 50px;
-  // max-width: 200px;
   max-width: 250px;
   text-align: center;
   padding-inline: 12px;

--- a/frontend/plugins/directives/tooltip.directive.js
+++ b/frontend/plugins/directives/tooltip.directive.js
@@ -17,7 +17,7 @@ Vue.directive("tooltip", {
     element.style.position = "relative";
     element.style.cursor = "pointer";
     let elementOffset = initElementOffset(element);
-    const {
+    let {
       content,
       backgroundColor,
       borderColor,
@@ -25,6 +25,8 @@ Vue.directive("tooltip", {
       width = 208,
       tooltipPosition = TOOLTIP_DIRECTION.BOTTOM,
     } = binding.value;
+
+    width = content.length > 100 ? (content.length > 300 ? 500 : 400) : 208;
 
     if (content?.length) {
       // NOTE - init tooltip node
@@ -254,6 +256,8 @@ const initTextStyle = (textWrapper, color = "rgba(0, 0, 0, 0.87)") => {
   textWrapper.style.fontWeight = "300";
   textWrapper.style.lineHeight = "18px";
   textWrapper.style.whiteSpace = "pre-wrap";
+  textWrapper.style.maxHeight = "200px";
+  textWrapper.style.overflowY = "scroll";
   textWrapper.style.color = `${color}`;
   return textWrapper;
 };

--- a/frontend/plugins/directives/tooltip.directive.js
+++ b/frontend/plugins/directives/tooltip.directive.js
@@ -17,15 +17,14 @@ Vue.directive("tooltip", {
     element.style.position = "relative";
     element.style.cursor = "pointer";
     let elementOffset = initElementOffset(element);
-    let {
+    const {
       content,
       backgroundColor,
       borderColor,
       color,
-      width = 208,
       tooltipPosition = TOOLTIP_DIRECTION.BOTTOM,
     } = binding.value;
-
+    let { width } = binding.value;
     width = content.length > 100 ? (content.length > 300 ? 500 : 400) : 208;
 
     if (content?.length) {


### PR DESCRIPTION
# Description

This PR is made to handle the request made by the researchers to extend the label width and the tooltip size. 

**How Has This Been Tested**

![Screenshot from 2023-10-17 19-49-15](https://github.com/CLARIN-PL/argilla/assets/12537724/c71638f1-cecb-4bdb-bb38-e6cd101230ce)
![Screenshot from 2023-10-17 19-51-14](https://github.com/CLARIN-PL/argilla/assets/12537724/391254b7-fda4-40a5-90ff-2bc0100b789d)

**Checklist**

- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)

**Modified files**

- `frontend/components/commons/forms/questions-form/fields/shared-components/label-selection/LabelSelection.component.vue`: bigger width 
- `frontend/plugins/directives/tooltip.directive.js`: added height, overflow scroll, adjusted the width based on the text length 

**Screenshots**

![Screenshot from 2023-10-17 13-51-48](https://github.com/CLARIN-PL/argilla/assets/12537724/4adcd1c3-dbb8-4265-9569-10a5c44bd0d9)
![Screenshot from 2023-10-17 13-50-59](https://github.com/CLARIN-PL/argilla/assets/12537724/70bb4a11-2910-4113-96c6-e2e387cef57f)

