### PR TITLE
Fix: BE - Enlargening number of shards - 2

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -31,7 +31,7 @@ services:
     environment:
       - node.name=elasticsearch
       - cluster.name=es-argilla-local
-      - cluster.max_shards_per_node=20000
+      - cluster.max_shards_per_node=50000
       - discovery.type=single-node
       - "ES_JAVA_OPTS=-Xms2g -Xmx2g"
       - cluster.routing.allocation.disk.threshold_enabled=false


### PR DESCRIPTION
This bug fix deals with https://github.com/CLARIN-PL/argilla/pull/11. It was already enlargened to 20k, but apparently it is not enough for 206 workspaces (41200 data), so it had to be enlargened again. 

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**How Has This Been Tested**

Tested by removing and recreating containers from scratch with existing databases. 

**Checklist**

- [ ] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)

**Modified files**

- `docker/docker-compose.yaml`: Enlargened the number of shards from 20k to 50k. 