### PR TITLE
Feat: FE - disable login button on login, fix regex for dates

### DIFF
--- a/frontend/components/base/render-markdown/RenderMarkdown.base.component.vue
+++ b/frontend/components/base/render-markdown/RenderMarkdown.base.component.vue
@@ -1,9 +1,5 @@
 <template>
-  <div
-    class="markdown-render"
-    v-html="markdownToHtml"
-    v-copy-code
-  />
+  <div class="markdown-render" v-html="markdownToHtml" v-copy-code />
 </template>
 <script>
 import { marked } from "marked";

--- a/frontend/components/base/render-markdown/RenderMarkdown.base.component.vue
+++ b/frontend/components/base/render-markdown/RenderMarkdown.base.component.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="markdown-render" v-html="markdownToHtml" v-copy-code />
+  <div
+    class="markdown-render"
+    v-html="markdownToHtml"
+    v-copy-code
+  />
 </template>
 <script>
 import { marked } from "marked";
@@ -28,7 +32,7 @@ export default {
     cleanMarkdown(markdown) {
       const markdowns = markdown
         .replace(/[^\S\r\n]+$/gm, "")
-        .split(/([1-9][0-9]?|100)[/.]/g);
+        .split(/(?<!dzień )([1-9][0-9]?|100)[/.][/ ]/g);
 
       let text =
         markdowns.length < 2

--- a/frontend/pages/login.vue
+++ b/frontend/pages/login.vue
@@ -18,10 +18,16 @@
 <template>
   <div class="container">
     <BaseLoading v-if="hasAuthToken" />
-    <form class="form" @submit.prevent="onLoginUser">
+    <form
+      class="form"
+      @submit.prevent="onLoginUser"
+    >
       <div class="form__header">
         <brand-logo class="form__logo" />
-        <select v-model="selectedLocale" class="form__lang-selector">
+        <select
+          v-model="selectedLocale"
+          class="form__lang-selector"
+        >
           <option
             v-for="(locale, idx) in $i18n.locales"
             :key="'option_' + idx"
@@ -36,7 +42,10 @@
         <p class="form__text">
           {{ $t("login.messages.pleaseEnterYourDetails") }}
         </p>
-        <div class="form__input" :class="{ active: login.username }">
+        <div
+          class="form__input"
+          :class="{ active: login.username }"
+        >
           <label class="form__label">{{ $t("login.username") }}</label>
           <input
             v-model="login.username"
@@ -44,7 +53,10 @@
             :placeholder="$t('login.guides.enterUsername')"
           />
         </div>
-        <div class="form__input" :class="{ active: login.password }">
+        <div
+          class="form__input"
+          :class="{ active: login.password }"
+        >
           <label class="form__label">{{ $t("login.password") }}</label>
           <input
             v-model="login.password"
@@ -57,14 +69,21 @@
           <a
             href="https://docs.argilla.io/en/latest/getting_started/quickstart.html"
             target="_blank"
-            >{{ $t("login.guides.thisGuide") }}</a
-          >
+          >{{ $t("login.guides.thisGuide") }}</a>
           {{ $t("login.guides.toLearnMore") }}
         </p>
-        <base-button type="submit" class="form__button primary">
+        <base-button
+          type="submit"
+          class="form__button primary"
+          :loading="loading"
+          :disabled="disabled"
+        >
           {{ $t("login.enter") }}
         </base-button>
-        <p class="form__error" v-if="error">{{ formattedError }}</p>
+        <p
+          class="form__error"
+          v-if="error"
+        >{{ formattedError }}</p>
       </div>
     </form>
     <div class="login--right">
@@ -75,8 +94,7 @@
         <a
           href="https://join.slack.com/t/rubrixworkspace/shared_invite/zt-whigkyjn-a3IUJLD7gDbTZ0rKlvcJ5g"
           target="_blank"
-          >Slack</a
-        >
+        >Slack</a>
       </p>
     </div>
   </div>
@@ -93,6 +111,8 @@ export default {
         username: "",
         password: "",
       },
+      loading: false,
+      disabled: false,
       deployment: false,
       hasAuthToken: false,
     };
@@ -104,7 +124,6 @@ export default {
 
     try {
       const [username, password] = atob(rawAuthToken).split(":");
-
       if (username && password) {
         this.hasAuthToken = true;
 
@@ -170,11 +189,18 @@ export default {
           show_discard_button: this.$auth.user.show_discard_button,
         },
       });
-
+      this.$nextTick(() => {
+        setTimeout(() => {
+          this.loading = false;
+          this.disabled = false;
+        }, 5000);
+      });
       this.nextRedirect();
     },
     async onLoginUser() {
       try {
+        this.loading = true;
+        this.disabled = true;
         await this.loginUser(this.login);
       } catch (err) {
         this.error = err;

--- a/frontend/pages/login.vue
+++ b/frontend/pages/login.vue
@@ -18,16 +18,10 @@
 <template>
   <div class="container">
     <BaseLoading v-if="hasAuthToken" />
-    <form
-      class="form"
-      @submit.prevent="onLoginUser"
-    >
+    <form class="form" @submit.prevent="onLoginUser">
       <div class="form__header">
         <brand-logo class="form__logo" />
-        <select
-          v-model="selectedLocale"
-          class="form__lang-selector"
-        >
+        <select v-model="selectedLocale" class="form__lang-selector">
           <option
             v-for="(locale, idx) in $i18n.locales"
             :key="'option_' + idx"
@@ -42,10 +36,7 @@
         <p class="form__text">
           {{ $t("login.messages.pleaseEnterYourDetails") }}
         </p>
-        <div
-          class="form__input"
-          :class="{ active: login.username }"
-        >
+        <div class="form__input" :class="{ active: login.username }">
           <label class="form__label">{{ $t("login.username") }}</label>
           <input
             v-model="login.username"
@@ -53,10 +44,7 @@
             :placeholder="$t('login.guides.enterUsername')"
           />
         </div>
-        <div
-          class="form__input"
-          :class="{ active: login.password }"
-        >
+        <div class="form__input" :class="{ active: login.password }">
           <label class="form__label">{{ $t("login.password") }}</label>
           <input
             v-model="login.password"
@@ -69,7 +57,8 @@
           <a
             href="https://docs.argilla.io/en/latest/getting_started/quickstart.html"
             target="_blank"
-          >{{ $t("login.guides.thisGuide") }}</a>
+            >{{ $t("login.guides.thisGuide") }}</a
+          >
           {{ $t("login.guides.toLearnMore") }}
         </p>
         <base-button
@@ -80,10 +69,7 @@
         >
           {{ $t("login.enter") }}
         </base-button>
-        <p
-          class="form__error"
-          v-if="error"
-        >{{ formattedError }}</p>
+        <p class="form__error" v-if="error">{{ formattedError }}</p>
       </div>
     </form>
     <div class="login--right">
@@ -94,7 +80,8 @@
         <a
           href="https://join.slack.com/t/rubrixworkspace/shared_invite/zt-whigkyjn-a3IUJLD7gDbTZ0rKlvcJ5g"
           target="_blank"
-        >Slack</a>
+          >Slack</a
+        >
       </p>
     </div>
   </div>


### PR DESCRIPTION
# Description

This PR handles the requests to disable the login button after clicking on it for 5 seconds. Additionally, I also fixed the regex to handle dates that started with `dzień` in the markdown component.

**Type of change**

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [x] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

![Screenshot from 2023-10-30 19-08-23](https://github.com/CLARIN-PL/argilla/assets/12537724/1722700a-0f6d-4d0a-98fb-6c931653b0ad)
![Screenshot from 2023-10-30 19-18-10](https://github.com/CLARIN-PL/argilla/assets/12537724/396d44ac-4769-497b-be97-7da17961d657)

**Checklist**

- [ ] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)

**Modified files**

- `frontend/components/base/render-markdown/RenderMarkdown.base.component.vue`: Updated the rule, now it will exclude numbers preceeded by `dzień` and not ended with ` `.
- `frontend/pages/login.vue` : disabled the button

**Screenshots: **
![Screenshot from 2023-10-30 16-46-39](https://github.com/CLARIN-PL/argilla/assets/12537724/fa757a02-abe2-44ff-b6cd-d081754fb356)
![Screenshot from 2023-10-30 18-00-59](https://github.com/CLARIN-PL/argilla/assets/12537724/ce44e998-10e1-4943-9024-69cd442017a3)
