### PR TITLE
Feat: Sort datasets by name.length < name < updated time

### DIFF
--- a/frontend/database/modules/datasets.js
+++ b/frontend/database/modules/datasets.js
@@ -887,9 +887,11 @@ const actions = {
             }
             return response.data;
           });
+
         await Promise.all(promises).then((values) => {
           canBreak = values.some((item) => item.is_completed === false);
         });
+
         if (canBreak) {
           currentProgress = 100;
           updateGeneralSettings(this.store.$auth.$state.user.id, {
@@ -908,6 +910,7 @@ const actions = {
           });
           setTimeout(() => {}, 1000);
         }
+        console.log(data);
       }
     }
 

--- a/frontend/pages/datasets/index.vue
+++ b/frontend/pages/datasets/index.vue
@@ -92,11 +92,12 @@ export default {
       return text;
     },
     datasetsOriginal() {
-      return this.datasets.datasets.map((dataset) => {
+      const datasets = this.datasets.datasets.map((dataset) => {
         dataset.link = this.getDatasetLink(dataset);
         dataset.workspace = dataset.workspace || dataset.workspaceName;
         return dataset;
       });
+      return datasets;
     },
     datasetsByPage() {
       const currentIndex =

--- a/frontend/v1/infrastructure/repositories/DatasetRepository.ts
+++ b/frontend/v1/infrastructure/repositories/DatasetRepository.ts
@@ -80,7 +80,18 @@ export class DatasetRepository implements IDatasetRepository {
         createdAt: dataset.createdAt || dataset.insertedAt,
       };
     });
-    let filteredDatasets = _.cloneDeep(datasets);
+    let filteredDatasets = _.cloneDeep(datasets)
+      .map((dataset) => {
+        dataset.workspace = dataset.workspace || dataset.workspaceName || "";
+        return dataset;
+      })
+      .sort((a, b) => {
+        return (
+          a.workspace.length - b.workspace.length ||
+          a.workspace.localeCompare(b.workspace) ||
+          a.updatedAt.localeCompare(b.updatedAt)
+        );
+      });
     const allowedRoles: any[] = ["admin", "owner"];
     if (!allowedRoles.includes(this.store.$auth.$state.user.role)) {
       const incompleteDatasets = filteredDatasets.filter(


### PR DESCRIPTION
Sort the datasets by workspace name and updatedAt. Previously it is only sorted by updatedAt (default from backend) 

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [ ] Improvement (change adding some improvement to an existing functionality)
- [ ] Documentation update

**How Has This Been Tested**

The build script runs well. 

**Checklist**

- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)

**Modified files**

- `frontend/v1/infrastructure/repositories/DatasetRepository.ts`: sorted the datasets 
